### PR TITLE
Fix for browserify parsing error

### DIFF
--- a/algos.js
+++ b/algos.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 exports['RSA-SHA224'] = exports.sha224WithRSAEncryption = {
   sign: 'rsa',
   hash: 'sha224',


### PR DESCRIPTION
Without this, I see
```
SyntaxError: Unexpected token (2:12) while parsing node_modules/browserify-sign/algos.js
```