### PR TITLE
Fix buffer deprecation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.11"
-  - "0.12"
-  - "4"
   - "5"
   - "6"
   - "7"
+  - "8"
+  - "10"
 matrix:
   include:
-    - node_js: "4"
+    - node_js: "10"
       env: TEST_SUITE=lint
 env:
   - TEST_SUITE=unit

--- a/browser/index.js
+++ b/browser/index.js
@@ -6,7 +6,7 @@ var verify = require('./verify')
 
 var algorithms = require('./algorithms.json')
 Object.keys(algorithms).forEach(function (key) {
-  algorithms[key].id = new Buffer(algorithms[key].id, 'hex')
+  algorithms[key].id = Buffer.from(algorithms[key].id, 'hex')
   algorithms[key.toLowerCase()] = algorithms[key]
 })
 
@@ -29,7 +29,7 @@ Sign.prototype._write = function _write (data, _, done) {
 }
 
 Sign.prototype.update = function update (data, enc) {
-  if (typeof data === 'string') data = new Buffer(data, enc)
+  if (typeof data === 'string') data = Buffer.from(data, enc)
 
   this._hash.update(data)
   return this
@@ -61,14 +61,14 @@ Verify.prototype._write = function _write (data, _, done) {
 }
 
 Verify.prototype.update = function update (data, enc) {
-  if (typeof data === 'string') data = new Buffer(data, enc)
+  if (typeof data === 'string') data = Buffer.from(data, enc)
 
   this._hash.update(data)
   return this
 }
 
 Verify.prototype.verify = function verifyMethod (key, sig, enc) {
-  if (typeof sig === 'string') sig = new Buffer(sig, enc)
+  if (typeof sig === 'string') sig = Buffer.from(sig, enc)
 
   this.end()
   var hash = this._hash.digest()

--- a/browser/sign.js
+++ b/browser/sign.js
@@ -38,7 +38,7 @@ function ecSign (hash, priv) {
   var key = curve.keyFromPrivate(priv.privateKey)
   var out = key.sign(hash)
 
-  return new Buffer(out.toDER())
+  return Buffer.from(out.toDER())
 }
 
 function dsaSign (hash, priv, algo) {
@@ -74,25 +74,25 @@ function toDER (r, s) {
   var total = r.length + s.length + 4
   var res = [ 0x30, total, 0x02, r.length ]
   res = res.concat(r, [ 0x02, s.length ], s)
-  return new Buffer(res)
+  return Buffer.from(res)
 }
 
 function getKey (x, q, hash, algo) {
-  x = new Buffer(x.toArray())
+  x = Buffer.from(x.toArray())
   if (x.length < q.byteLength()) {
-    var zeros = new Buffer(q.byteLength() - x.length)
+    var zeros = Buffer.alloc(q.byteLength() - x.length)
     zeros.fill(0)
     x = Buffer.concat([ zeros, x ])
   }
   var hlen = hash.length
   var hbits = bits2octets(hash, q)
-  var v = new Buffer(hlen)
+  var v = Buffer.alloc(hlen)
   v.fill(1)
-  var k = new Buffer(hlen)
+  var k = Buffer.alloc(hlen)
   k.fill(0)
-  k = createHmac(algo, k).update(v).update(new Buffer([ 0 ])).update(x).update(hbits).digest()
+  k = createHmac(algo, k).update(v).update(Buffer.from([ 0 ])).update(x).update(hbits).digest()
   v = createHmac(algo, k).update(v).digest()
-  k = createHmac(algo, k).update(v).update(new Buffer([ 1 ])).update(x).update(hbits).digest()
+  k = createHmac(algo, k).update(v).update(Buffer.from([ 1 ])).update(x).update(hbits).digest()
   v = createHmac(algo, k).update(v).digest()
   return { k: k, v: v }
 }
@@ -107,9 +107,9 @@ function bits2int (obits, q) {
 function bits2octets (bits, q) {
   bits = bits2int(bits, q)
   bits = bits.mod(q)
-  var out = new Buffer(bits.toArray())
+  var out = Buffer.from(bits.toArray())
   if (out.length < q.byteLength()) {
-    var zeros = new Buffer(q.byteLength() - out.length)
+    var zeros = Buffer.alloc(q.byteLength() - out.length)
     zeros.fill(0)
     out = Buffer.concat([ zeros, out ])
   }
@@ -121,7 +121,7 @@ function makeKey (q, kv, algo) {
   var k
 
   do {
-    t = new Buffer(0)
+    t = Buffer.alloc(0)
 
     while (t.length * 8 < q.bitLength()) {
       kv.v = createHmac(algo, kv.k).update(kv.v).digest()
@@ -129,7 +129,7 @@ function makeKey (q, kv, algo) {
     }
 
     k = bits2int(t, q)
-    kv.k = createHmac(algo, kv.k).update(kv.v).update(new Buffer([ 0 ])).digest()
+    kv.k = createHmac(algo, kv.k).update(kv.v).update(Buffer.from([ 0 ])).digest()
     kv.v = createHmac(algo, kv.k).update(kv.v).digest()
   } while (k.cmp(q) !== -1)
 

--- a/browser/verify.js
+++ b/browser/verify.js
@@ -29,12 +29,12 @@ function verify (sig, hash, key, signType, tag) {
   while (++i < hash.length) {
     pad.push(hash[i])
   }
-  pad = new Buffer(pad)
+  pad = Buffer.from(pad)
   var red = BN.mont(pub.modulus)
   sig = new BN(sig).toRed(red)
 
   sig = sig.redPow(new BN(pub.publicExponent))
-  sig = new Buffer(sig.fromRed().toArray())
+  sig = Buffer.from(sig.fromRed().toArray())
   var out = padNum < 8 ? 1 : 0
   len = Math.min(sig.length, pad.length)
   if (sig.length !== pad.length) out = 1

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^4.1.1",
+    "bn.js": "^5.0.0",
     "browserify-rsa": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^5.0.0",
+    "bn.js": "^5.1.1",
     "browserify-rsa": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.2",

--- a/test/index.js
+++ b/test/index.js
@@ -9,8 +9,8 @@ function isNode10 () {
 }
 
 fixtures.valid.rsa.forEach(function (f) {
-  var message = new Buffer(f.message)
-  var pub = new Buffer(f.public, 'base64')
+  var message = Buffer.from(f.message)
+  var pub = Buffer.from(f.public, 'base64')
   var priv
 
   // skip passphrase tests in node 10
@@ -18,11 +18,11 @@ fixtures.valid.rsa.forEach(function (f) {
 
   if (f.passphrase) {
     priv = {
-      key: new Buffer(f.private, 'base64'),
+      key: Buffer.from(f.private, 'base64'),
       passphrase: f.passphrase
     }
   } else {
-    priv = new Buffer(f.private, 'base64')
+    priv = Buffer.from(f.private, 'base64')
   }
 
   test(f.message, function (t) {
@@ -46,8 +46,8 @@ fixtures.valid.rsa.forEach(function (f) {
 })
 
 fixtures.valid.ec.forEach(function (f) {
-  var message = new Buffer(f.message)
-  var pub = new Buffer(f.public, 'base64')
+  var message = Buffer.from(f.message)
+  var pub = Buffer.from(f.public, 'base64')
   var priv
 
   // skip passphrase tests in node 10
@@ -55,11 +55,11 @@ fixtures.valid.ec.forEach(function (f) {
 
   if (f.passphrase) {
     priv = {
-      key: new Buffer(f.private, 'base64'),
+      key: Buffer.from(f.private, 'base64'),
       passphrase: f.passphrase
     }
   } else {
-    priv = new Buffer(f.private, 'base64')
+    priv = Buffer.from(f.private, 'base64')
   }
 
   test(f.message, function (t) {
@@ -103,7 +103,7 @@ fixtures.valid.ec.forEach(function (f) {
 
 fixtures.valid.kvectors.forEach(function (f) {
   test('kvector algo: ' + f.algo + ' key len: ' + f.key.length + ' msg: ' + f.msg, function (t) {
-    var key = new Buffer(f.key, 'base64')
+    var key = Buffer.from(f.key, 'base64')
 
     var bSig = bCrypto.createSign(f.algo).update(f.msg).sign(key)
     var bRS = asn1.signature.decode(bSig, 'der')
@@ -116,9 +116,9 @@ fixtures.valid.kvectors.forEach(function (f) {
 
 fixtures.invalid.verify.forEach(function (f) {
   test(f.description, function (t) {
-    var sign = new Buffer(f.signature, 'hex')
-    var pub = new Buffer(f.public, 'base64')
-    var message = new Buffer(f.message)
+    var sign = Buffer.from(f.signature, 'hex')
+    var pub = Buffer.from(f.public, 'base64')
+    var message = Buffer.from(f.message)
 
     var nVerify = nCrypto.createVerify(f.scheme).update(message).verify(pub, sign)
     t.notOk(nVerify, 'node rejects it')


### PR DESCRIPTION
This requires to drop legacy Node.js priort to 5, since Buffer factory
methods are added in Node.js 5.10.