### PR TITLE
bump bn.js to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^4.1.1",
+    "bn.js": "^5.0.0",
     "browserify-rsa": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.2",


### PR DESCRIPTION
https://github.com/indutny/elliptic/issues/191 (`browserify-sign` need bump to 4.1.0)
Tests will fail, but locally I manually changed `yarn.lock` to use `bn.js@^5.0.0` only and tests were pass with `node@7`

Depends from:
- https://github.com/crypto-browserify/browserify-rsa/pull/13