### PR TITLE
update deps, modernise usage, use readable-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.11"
-  - "0.12"
-  - "4"
-  - "5"
-  - "6"
-  - "7"
+  - "8"
+  - "10"
+  - "12"
+  - "14"
+  - lts/*
+  - current
 matrix:
   include:
-    - node_js: "4"
+    - node_js: "12"
       env: TEST_SUITE=lint
 env:
   - TEST_SUITE=unit

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,5 +1,5 @@
 var createHash = require('create-hash')
-var stream = require('stream')
+var stream = require('readable-stream')
 var inherits = require('inherits')
 var sign = require('./sign')
 var verify = require('./verify')

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,3 +1,4 @@
+var Buffer = require('buffer').Buffer
 var createHash = require('create-hash')
 var stream = require('readable-stream')
 var inherits = require('inherits')
@@ -6,7 +7,7 @@ var verify = require('./verify')
 
 var algorithms = require('./algorithms.json')
 Object.keys(algorithms).forEach(function (key) {
-  algorithms[key].id = new Buffer(algorithms[key].id, 'hex')
+  algorithms[key].id = Buffer.from(algorithms[key].id, 'hex')
   algorithms[key.toLowerCase()] = algorithms[key]
 })
 
@@ -29,7 +30,7 @@ Sign.prototype._write = function _write (data, _, done) {
 }
 
 Sign.prototype.update = function update (data, enc) {
-  if (typeof data === 'string') data = new Buffer(data, enc)
+  if (typeof data === 'string') data = Buffer.from(data, enc)
 
   this._hash.update(data)
   return this
@@ -61,14 +62,14 @@ Verify.prototype._write = function _write (data, _, done) {
 }
 
 Verify.prototype.update = function update (data, enc) {
-  if (typeof data === 'string') data = new Buffer(data, enc)
+  if (typeof data === 'string') data = Buffer.from(data, enc)
 
   this._hash.update(data)
   return this
 }
 
 Verify.prototype.verify = function verifyMethod (key, sig, enc) {
-  if (typeof sig === 'string') sig = new Buffer(sig, enc)
+  if (typeof sig === 'string') sig = Buffer.from(sig, enc)
 
   this.end()
   var hash = this._hash.digest()

--- a/browser/sign.js
+++ b/browser/sign.js
@@ -1,4 +1,5 @@
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
+var Buffer = require('buffer').Buffer
 var createHmac = require('create-hmac')
 var crt = require('browserify-rsa')
 var EC = require('elliptic').ec
@@ -80,16 +81,14 @@ function toDER (r, s) {
 function getKey (x, q, hash, algo) {
   x = Buffer.from(x.toArray())
   if (x.length < q.byteLength()) {
-    var zeros = Buffer.from(q.byteLength() - x.length)
-    zeros.fill(0)
+    var zeros = Buffer.alloc(q.byteLength() - x.length)
     x = Buffer.concat([zeros, x])
   }
   var hlen = hash.length
   var hbits = bits2octets(hash, q)
-  var v = Buffer.from(hlen)
+  var v = Buffer.alloc(hlen)
   v.fill(1)
-  var k = Buffer.from(hlen)
-  k.fill(0)
+  var k = Buffer.alloc(hlen)
   k = createHmac(algo, k).update(v).update(Buffer.from([0])).update(x).update(hbits).digest()
   v = createHmac(algo, k).update(v).digest()
   k = createHmac(algo, k).update(v).update(Buffer.from([1])).update(x).update(hbits).digest()
@@ -109,8 +108,7 @@ function bits2octets (bits, q) {
   bits = bits.mod(q)
   var out = Buffer.from(bits.toArray())
   if (out.length < q.byteLength()) {
-    var zeros = Buffer.from(q.byteLength() - out.length)
-    zeros.fill(0)
+    var zeros = Buffer.alloc(q.byteLength() - out.length)
     out = Buffer.concat([zeros, out])
   }
   return out
@@ -121,7 +119,7 @@ function makeKey (q, kv, algo) {
   var k
 
   do {
-    t = Buffer.from(0)
+    t = Buffer.alloc(0)
 
     while (t.length * 8 < q.bitLength()) {
       kv.v = createHmac(algo, kv.k).update(kv.v).digest()

--- a/browser/sign.js
+++ b/browser/sign.js
@@ -20,7 +20,7 @@ function sign (hash, key, hashType, signType, tag) {
   }
   hash = Buffer.concat([tag, hash])
   var len = priv.modulus.byteLength()
-  var pad = [ 0, 1 ]
+  var pad = [0, 1]
   while (hash.length + pad.length + 1 < len) pad.push(0xff)
   pad.push(0x00)
   var i = -1
@@ -38,7 +38,7 @@ function ecSign (hash, priv) {
   var key = curve.keyFromPrivate(priv.privateKey)
   var out = key.sign(hash)
 
-  return new Buffer(out.toDER())
+  return Buffer.from(out.toDER())
 }
 
 function dsaSign (hash, priv, algo) {
@@ -68,31 +68,31 @@ function toDER (r, s) {
   s = s.toArray()
 
   // Pad values
-  if (r[0] & 0x80) r = [ 0 ].concat(r)
-  if (s[0] & 0x80) s = [ 0 ].concat(s)
+  if (r[0] & 0x80) r = [0].concat(r)
+  if (s[0] & 0x80) s = [0].concat(s)
 
   var total = r.length + s.length + 4
-  var res = [ 0x30, total, 0x02, r.length ]
-  res = res.concat(r, [ 0x02, s.length ], s)
-  return new Buffer(res)
+  var res = [0x30, total, 0x02, r.length]
+  res = res.concat(r, [0x02, s.length], s)
+  return Buffer.from(res)
 }
 
 function getKey (x, q, hash, algo) {
-  x = new Buffer(x.toArray())
+  x = Buffer.from(x.toArray())
   if (x.length < q.byteLength()) {
-    var zeros = new Buffer(q.byteLength() - x.length)
+    var zeros = Buffer.from(q.byteLength() - x.length)
     zeros.fill(0)
-    x = Buffer.concat([ zeros, x ])
+    x = Buffer.concat([zeros, x])
   }
   var hlen = hash.length
   var hbits = bits2octets(hash, q)
-  var v = new Buffer(hlen)
+  var v = Buffer.from(hlen)
   v.fill(1)
-  var k = new Buffer(hlen)
+  var k = Buffer.from(hlen)
   k.fill(0)
-  k = createHmac(algo, k).update(v).update(new Buffer([ 0 ])).update(x).update(hbits).digest()
+  k = createHmac(algo, k).update(v).update(Buffer.from([0])).update(x).update(hbits).digest()
   v = createHmac(algo, k).update(v).digest()
-  k = createHmac(algo, k).update(v).update(new Buffer([ 1 ])).update(x).update(hbits).digest()
+  k = createHmac(algo, k).update(v).update(Buffer.from([1])).update(x).update(hbits).digest()
   v = createHmac(algo, k).update(v).digest()
   return { k: k, v: v }
 }
@@ -107,11 +107,11 @@ function bits2int (obits, q) {
 function bits2octets (bits, q) {
   bits = bits2int(bits, q)
   bits = bits.mod(q)
-  var out = new Buffer(bits.toArray())
+  var out = Buffer.from(bits.toArray())
   if (out.length < q.byteLength()) {
-    var zeros = new Buffer(q.byteLength() - out.length)
+    var zeros = Buffer.from(q.byteLength() - out.length)
     zeros.fill(0)
-    out = Buffer.concat([ zeros, out ])
+    out = Buffer.concat([zeros, out])
   }
   return out
 }
@@ -121,15 +121,15 @@ function makeKey (q, kv, algo) {
   var k
 
   do {
-    t = new Buffer(0)
+    t = Buffer.from(0)
 
     while (t.length * 8 < q.bitLength()) {
       kv.v = createHmac(algo, kv.k).update(kv.v).digest()
-      t = Buffer.concat([ t, kv.v ])
+      t = Buffer.concat([t, kv.v])
     }
 
     k = bits2int(t, q)
-    kv.k = createHmac(algo, kv.k).update(kv.v).update(new Buffer([ 0 ])).digest()
+    kv.k = createHmac(algo, kv.k).update(kv.v).update(Buffer.from([0])).digest()
     kv.v = createHmac(algo, kv.k).update(kv.v).digest()
   } while (k.cmp(q) !== -1)
 

--- a/browser/verify.js
+++ b/browser/verify.js
@@ -1,4 +1,5 @@
 // much of this based on https://github.com/indutny/self-signed/blob/gh-pages/lib/rsa.js
+var Buffer = require('buffer').Buffer
 var BN = require('bn.js')
 var EC = require('elliptic').ec
 var parseKeys = require('parse-asn1')
@@ -29,12 +30,12 @@ function verify (sig, hash, key, signType, tag) {
   while (++i < hash.length) {
     pad.push(hash[i])
   }
-  pad = new Buffer(pad)
+  pad = Buffer.from(pad)
   var red = BN.mont(pub.modulus)
   sig = new BN(sig).toRed(red)
 
   sig = sig.redPow(new BN(pub.publicExponent))
-  sig = new Buffer(sig.fromRed().toArray())
+  sig = Buffer.from(sig.fromRed().toArray())
   var out = padNum < 8 ? 1 : 0
   len = Math.min(sig.length, pad.length)
   if (sig.length !== pad.length) out = 1

--- a/browser/verify.js
+++ b/browser/verify.js
@@ -18,7 +18,7 @@ function verify (sig, hash, key, signType, tag) {
   }
   hash = Buffer.concat([tag, hash])
   var len = pub.modulus.byteLength()
-  var pad = [ 1 ]
+  var pad = [1]
   var padNum = 0
   while (hash.length + pad.length + 2 < len) {
     pad.push(0xff)

--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "bn.js": "^4.1.1",
-    "browserify-rsa": "^4.0.0",
-    "create-hash": "^1.1.0",
-    "create-hmac": "^1.1.2",
-    "elliptic": "^6.0.0",
-    "inherits": "^2.0.1",
-    "parse-asn1": "^5.0.0",
+    "bn.js": "^5.1.1",
+    "browserify-rsa": "^4.0.1",
+    "create-hash": "^1.2.0",
+    "create-hmac": "^1.1.7",
+    "elliptic": "^6.5.2",
+    "inherits": "^2.0.4",
+    "parse-asn1": "^5.1.5",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {
-    "nyc": "^6.1.1",
-    "standard": "^6.0.8",
-    "tape": "^4.5.1"
+    "nyc": "^15.0.1",
+    "standard": "^14.3.3",
+    "tape": "^5.0.0"
   },
   "browser": "browser/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "create-hmac": "^1.1.2",
     "elliptic": "^6.0.0",
     "inherits": "^2.0.1",
-    "parse-asn1": "^5.0.0"
+    "parse-asn1": "^5.0.0",
+    "readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "nyc": "^6.1.1",

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ fixtures.valid.ec.forEach(function (f) {
     priv = Buffer.from(f.private, 'base64')
   }
 
-  test(f.message, function (t) {
+  (nCrypto.getHashes().includes(f.scheme) ? test : test.skip)(f.message, function (t) {
     var nSign = nCrypto.createSign(f.scheme)
     var bSign = bCrypto.createSign(f.scheme)
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+var Buffer = require('buffer').Buffer
 var asn1 = require('parse-asn1/asn1')
 var test = require('tape').test
 var nCrypto = require('crypto')
@@ -9,8 +10,8 @@ function isNode10 () {
 }
 
 fixtures.valid.rsa.forEach(function (f) {
-  var message = new Buffer(f.message)
-  var pub = new Buffer(f.public, 'base64')
+  var message = Buffer.from(f.message)
+  var pub = Buffer.from(f.public, 'base64')
   var priv
 
   // skip passphrase tests in node 10
@@ -18,11 +19,11 @@ fixtures.valid.rsa.forEach(function (f) {
 
   if (f.passphrase) {
     priv = {
-      key: new Buffer(f.private, 'base64'),
+      key: Buffer.from(f.private, 'base64'),
       passphrase: f.passphrase
     }
   } else {
-    priv = new Buffer(f.private, 'base64')
+    priv = Buffer.from(f.private, 'base64')
   }
 
   test(f.message, function (t) {
@@ -46,8 +47,8 @@ fixtures.valid.rsa.forEach(function (f) {
 })
 
 fixtures.valid.ec.forEach(function (f) {
-  var message = new Buffer(f.message)
-  var pub = new Buffer(f.public, 'base64')
+  var message = Buffer.from(f.message)
+  var pub = Buffer.from(f.public, 'base64')
   var priv
 
   // skip passphrase tests in node 10
@@ -55,11 +56,11 @@ fixtures.valid.ec.forEach(function (f) {
 
   if (f.passphrase) {
     priv = {
-      key: new Buffer(f.private, 'base64'),
+      key: Buffer.from(f.private, 'base64'),
       passphrase: f.passphrase
     }
   } else {
-    priv = new Buffer(f.private, 'base64')
+    priv = Buffer.from(f.private, 'base64')
   }
 
   test(f.message, function (t) {
@@ -103,7 +104,7 @@ fixtures.valid.ec.forEach(function (f) {
 
 fixtures.valid.kvectors.forEach(function (f) {
   test('kvector algo: ' + f.algo + ' key len: ' + f.key.length + ' msg: ' + f.msg, function (t) {
-    var key = new Buffer(f.key, 'base64')
+    var key = Buffer.from(f.key, 'base64')
 
     var bSig = bCrypto.createSign(f.algo).update(f.msg).sign(key)
     var bRS = asn1.signature.decode(bSig, 'der')
@@ -116,9 +117,9 @@ fixtures.valid.kvectors.forEach(function (f) {
 
 fixtures.invalid.verify.forEach(function (f) {
   test(f.description, function (t) {
-    var sign = new Buffer(f.signature, 'hex')
-    var pub = new Buffer(f.public, 'base64')
-    var message = new Buffer(f.message)
+    var sign = Buffer.from(f.signature, 'hex')
+    var pub = Buffer.from(f.public, 'base64')
+    var message = Buffer.from(f.message)
 
     var nVerify = nCrypto.createVerify(f.scheme).update(message).verify(pub, sign)
     t.notOk(nVerify, 'node rejects it')


### PR DESCRIPTION
some modernisation:

* use readable-stream rather than stream to prevent breakage and fix to a specific version (stream_browserify is currently being a pain because of upstream breakage)
* update dependencies, fix all security warnings
* update standard and fix all linting errors
* switch from `new Buffer()` to `Buffer.alloc()` and `Buffer.from()`
* skip tests for signatures where the algorithm isn't supported by Node.js (main algos that use DSA and SHA1 which have been removed from the default OpenSSL bundle now used)
* update travis descriptor to run on latest versions of Node.js
* _(edit: updated)_ added explicit `require('buffer').Buffer` to make it safe for Webpack 5 et. al. that are dropping node.js buildins.