### PR TITLE
add buffer package for use in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "bn.js": "^5.1.1",
     "browserify-rsa": "^4.0.1",
+    "buffer": "^5.6.0",
     "create-hash": "^1.2.0",
     "create-hmac": "^1.1.7",
     "elliptic": "^6.5.2",


### PR DESCRIPTION
Ref #50 

This is only used in the browser, Node.js will default to core buffer, so the main cost of this is the dependency weight, but it adds nice future proofing for the browser and Webpack.